### PR TITLE
fix: grail builder mobile layout

### DIFF
--- a/src/GrailBuilder.css
+++ b/src/GrailBuilder.css
@@ -8,13 +8,20 @@
   flex-direction: column;
   align-items: center;
   margin-top: 30px;
-  min-height: 1000px;
 }
 
 .grail-builder__preview-container {
   position: sticky;
-  top: 50%;
-  transform: translateY(-50%);
+
+  /* To center the preview when the container is sticking. 250px
+  is half the height of the preview image */
+  top: calc(100vh - 50% - 200px);
+}
+
+.grail-builder__placeholder-image {
+  background-size: cover;
+  width: 400px;
+  height: 400px;
 }
 
 .grail-builder__tokens {

--- a/src/GrailBuilder.css
+++ b/src/GrailBuilder.css
@@ -13,15 +13,15 @@
 .grail-builder__preview-container {
   position: sticky;
 
-  /* To center the preview when the container is sticking. 250px
+  /* To center the preview when the container is sticking. 225px
   is half the height of the preview image */
-  top: calc(100vh - 50% - 200px);
+  top: calc(100vh - 50% - 225px);
 }
 
 .grail-builder__placeholder-image {
   background-size: cover;
-  width: 400px;
-  height: 400px;
+  width: 450px;
+  height: 450px;
 }
 
 .grail-builder__tokens {

--- a/src/GrailBuilder.tsx
+++ b/src/GrailBuilder.tsx
@@ -19,17 +19,13 @@ interface GrailState {
 function GrailPreview({ svgData }: { svgData: string }) {
   return (
     <div
-      style={{
-        width: 500,
-        height: 500,
-        backgroundImage: `url(${placeholderImage})`,
-        backgroundSize: 'cover',
-      }}
+      className="grail-builder__placeholder-image"
+      style={{ backgroundImage: `url(${placeholderImage})` }}
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
-        width="500"
-        height="500"
+        width="100%"
+        height="100%"
         viewBox="0 0 25 25"
         dangerouslySetInnerHTML={{ __html: svgData }}
       />

--- a/src/mobile.css
+++ b/src/mobile.css
@@ -72,5 +72,29 @@
 
   .submit-swap-button {
     width: calc(100vw - 32px);
-}
+  }
+
+  /* GRAIL BUILDER */
+
+  .grail-builder {
+    flex-direction: column;
+  }
+
+  .grail-builder__preview {
+    position: sticky;
+    top: 0;
+    padding: 10px;
+    border-bottom: 1px solid black;
+    background: white;
+  }
+
+  .grail-builder__tokens {
+    overflow: hidden;
+  }
+
+  .grail-builder__placeholder-image {
+    height: 25vh;
+    min-height: 200px;
+    width: 100%;
+  }
 }

--- a/src/mobile.css
+++ b/src/mobile.css
@@ -86,6 +86,7 @@
     padding: 10px;
     border-bottom: 1px solid black;
     background: white;
+    margin: 0;
   }
 
   .grail-builder__tokens {

--- a/src/mobile.css
+++ b/src/mobile.css
@@ -92,6 +92,10 @@
     overflow: hidden;
   }
 
+  .grail-builder__parts {
+    overflow-x: auto;
+  }
+
   .grail-builder__placeholder-image {
     height: 25vh;
     min-height: 200px;


### PR DESCRIPTION
On mobile, preview will stick to the top of the screen, and the parts rows will be horizontally scrollable

scrolled to top|stickied
---|---
![image](https://user-images.githubusercontent.com/3383858/143894071-886a135a-fea5-4675-a9d7-b0058bc5da48.png)|![image](https://user-images.githubusercontent.com/3383858/143893165-4c24766a-0cea-4f7a-871c-efd8f90e5f17.png)
